### PR TITLE
Refactor shader class

### DIFF
--- a/examples/lines.cpp
+++ b/examples/lines.cpp
@@ -17,7 +17,13 @@ auto main() -> int
   blossom::window window(WINDOW_WIDTH, WINDOW_HEIGHT, window_title);
   window.enter_fullscreen();
 
-  blossom::shader default_shader {"shaders/default.frag", "shaders/default.vert"};
+  const blossom::shader_info SHADER_INFO
+  {
+    .vertex_shader_path   = "shaders/default.vert",
+    .fragment_shader_path = "shaders/default.frag"
+  };
+
+  const GLuint SHADER_PROGRAM_ID = blossom::shader::compile(SHADER_INFO);
 
   // Vertices (start and end points) for a line
   const glm::vec3 LINE_START_POINT = {-200.0F, 0.0F, 0.0F};
@@ -45,13 +51,13 @@ auto main() -> int
 
   blossom::factory::line(
       registry,
-      default_shader.program_id,
+      SHADER_PROGRAM_ID,
       LINE_START_POINT,
       LINE_END_POINT);
 
   blossom::factory::line(
       registry,
-      default_shader.program_id,
+      SHADER_PROGRAM_ID,
       line_strip_points);
 
   blossom::system::transform::update(registry);

--- a/examples/multi_cube.cpp
+++ b/examples/multi_cube.cpp
@@ -11,8 +11,6 @@ const unsigned int TOTAL_CUBES = 1000000;
 const unsigned int NUM_VAOS = 1;
 const unsigned int NUM_VBOS = 2;
 
-GLuint rendering_program; 
-
 glm::vec3 camera_pos;
 
 GLuint vao[NUM_VAOS]; 
@@ -49,15 +47,15 @@ void init_vertices()
   glBufferData (GL_ARRAY_BUFFER, sizeof(vertex_positions), vertex_positions, GL_STATIC_DRAW);
 }
 
-void render_cube(GLFWwindow* window, glm::vec3 cube_pos, double& time) 
+void render_cube(GLFWwindow* window, glm::vec3 cube_pos, double& time, GLuint shader_program) 
 {
   GLuint v_loc, proj_loc, t_loc, m_loc;
   glm::mat4 p_mat, v_mat, m_mat;
 
-  v_loc = glGetUniformLocation (rendering_program, "v_matrix");
-  proj_loc = glGetUniformLocation (rendering_program, "proj_matrix");
-  m_loc = glGetUniformLocation (rendering_program, "m_matrix");
-  t_loc = glGetUniformLocation (rendering_program, "tf");
+  v_loc = glGetUniformLocation (shader_program, "v_matrix");
+  proj_loc = glGetUniformLocation (shader_program, "proj_matrix");
+  m_loc = glGetUniformLocation (shader_program, "m_matrix");
+  t_loc = glGetUniformLocation (shader_program, "tf");
 
   // building the perspective matrix
 
@@ -76,16 +74,16 @@ void render_cube(GLFWwindow* window, glm::vec3 cube_pos, double& time)
   glUniform1f (t_loc, static_cast<float>(time));
 }
 
-void display(GLFWwindow* window, double time) 
+void display(GLFWwindow* window, double time, GLuint shader_program) 
 {
   glClearColor (0.0, 0.0, 0.0, 1.0);
   glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-  glUseProgram (rendering_program);
+  glUseProgram (shader_program);
   glEnable (GL_DEPTH_TEST);
   glDepthFunc (GL_LEQUAL);
   glDrawArraysInstanced (GL_TRIANGLES, 0, 36, TOTAL_CUBES);
 
-  render_cube(window, {0.0f, 0.0f, 1.0f}, time);
+  render_cube(window, {0.0f, 0.0f, 1.0f}, time, shader_program);
 }
 
 int main(void) 
@@ -95,8 +93,13 @@ int main(void)
 
   init_vertices();
 
-  blossom::shader s ("shaders/multi_cube.frag", "shaders/multi_cube.vert");
-  rendering_program = s.program_id;
+  const blossom::shader_info SHADER_INFO
+  {
+    .vertex_shader_path   = "shaders/multi_cube.vert",
+    .fragment_shader_path = "shaders/multi_cube.frag"
+  };
+
+  const GLuint SHADER_PROGRAM_ID = blossom::shader::compile(SHADER_INFO);
 
   while ( !glfwWindowShouldClose(w.window_ptr) ) 
   {
@@ -119,7 +122,7 @@ int main(void)
     else if (glfwGetKey(w.window_ptr, GLFW_KEY_A) == GLFW_PRESS) {
       camera_pos[0] -= 5000.0 * delta_time;
     }
-    display(w.window_ptr, glfwGetTime());
+    display(w.window_ptr, glfwGetTime(), SHADER_PROGRAM_ID);
     glfwSwapBuffers(w.window_ptr); // swaps the front and back colour buffers
     glfwPollEvents();
   }

--- a/examples/rectangle_camera.cpp
+++ b/examples/rectangle_camera.cpp
@@ -17,7 +17,13 @@ auto main() -> int
   blossom::window window(WINDOW_WIDTH, WINDOW_HEIGHT, window_title);
   window.enter_fullscreen();
 
-  blossom::shader default_shader {"shaders/default.frag", "shaders/default.vert"};
+  const blossom::shader_info SHADER_INFO
+  {
+    .vertex_shader_path   = "shaders/default.vert",
+    .fragment_shader_path = "shaders/default.frag"
+  };
+
+  const GLuint SHADER_PROGRAM_ID = blossom::shader::compile(SHADER_INFO);
 
   entt::registry registry;
 
@@ -30,7 +36,7 @@ auto main() -> int
       registry, 
       RECTANGLE_POSITION, 
       RECTANGLE_SCALE,
-      default_shader.program_id);
+      SHADER_PROGRAM_ID);
 
   blossom::factory::camera{registry}
     .with_width    (WINDOW_WIDTH)

--- a/examples/triangle.cpp
+++ b/examples/triangle.cpp
@@ -17,7 +17,13 @@ auto main() -> int
   blossom::window window(WINDOW_WIDTH, WINDOW_HEIGHT, window_title);
   window.enter_fullscreen();
 
-  blossom::shader default_shader {"shaders/default.frag", "shaders/default.vert"};
+  const blossom::shader_info SHADER_INFO
+  {
+    .vertex_shader_path   = "shaders/default.vert",
+    .fragment_shader_path = "shaders/default.frag"
+  };
+
+  const GLuint SHADER_PROGRAM_ID = blossom::shader::compile(SHADER_INFO);
 
   std::vector<glm::vec3> triangle_vertices =
   {
@@ -41,7 +47,7 @@ auto main() -> int
   blossom::factory::mesh(registry)
     .with_vertices(triangle_vertices)
     .with_scale(TRIANGLE_SCALE)
-    .with_shader_program(default_shader.program_id)
+    .with_shader_program(SHADER_PROGRAM_ID)
     .build();
 
   blossom::system::transform::update(registry);

--- a/examples/view.cpp
+++ b/examples/view.cpp
@@ -12,47 +12,53 @@ const char* window_title = "Blossom Mesh View Example";
 
 auto main() -> int
 {
-    blossom::window window(WINDOW_WIDTH, WINDOW_HEIGHT, window_title);
+  blossom::window window(WINDOW_WIDTH, WINDOW_HEIGHT, window_title);
 
-    glClearColor(0.0, 0.0, 0.0, 1.0);
-    glEnable(GL_DEPTH_TEST);
-    glDepthFunc(GL_LEQUAL);
+  glClearColor(0.0, 0.0, 0.0, 1.0);
+  glEnable(GL_DEPTH_TEST);
+  glDepthFunc(GL_LEQUAL);
 
-    entt::registry registry;
+  entt::registry registry;
 
-    constexpr glm::vec3 CAMERA_POSITION = { 0.0F, 1.0F, 1.0F };
-    constexpr glm::vec3 CAMERA_ROTATION = {-45.0F, 0.0F,  0.0F};
+  constexpr glm::vec3 CAMERA_POSITION = { 0.0F, 1.0F, 1.0F };
+  constexpr glm::vec3 CAMERA_ROTATION = {-45.0F, 0.0F,  0.0F};
 
-    constexpr float CAMERA_FOV_Y = 90.0F;
+  constexpr float CAMERA_FOV_Y = 90.0F;
 
-    blossom::factory::camera{registry}
-      .with_width (WINDOW_WIDTH)
-      .with_height(WINDOW_HEIGHT)
-      .with_fov_y (CAMERA_FOV_Y)
-      .with_position(CAMERA_POSITION)
-      .with_rotation(CAMERA_ROTATION)
-      .with_type(blossom::component::camera::camera_type::PERSPECTIVE)
-      .make_active();
+  blossom::factory::camera{registry}
+  .with_width (WINDOW_WIDTH)
+    .with_height(WINDOW_HEIGHT)
+    .with_fov_y (CAMERA_FOV_Y)
+    .with_position(CAMERA_POSITION)
+    .with_rotation(CAMERA_ROTATION)
+    .with_type(blossom::component::camera::camera_type::PERSPECTIVE)
+    .make_active();
 
-    blossom::shader default_shader("shaders/random.frag", "shaders/default.vert");
+  const blossom::shader_info SHADER_INFO
+  {
+    .vertex_shader_path   = "shaders/default.vert",
+    .fragment_shader_path = "shaders/random.frag"
+  };
 
-    blossom::factory::sphere(
-          registry,
-          1.0F,
-          32,
-          16,
-          default_shader.program_id);
+  const GLuint SHADER_PROGRAM_ID = blossom::shader::compile(SHADER_INFO);
 
-    blossom::system::transform::update(registry);
-    blossom::system::camera::update(registry);
+  blossom::factory::sphere(
+      registry,
+      1.0F,
+      32,
+      16,
+      SHADER_PROGRAM_ID);
 
-    while (glfwWindowShouldClose(window.window_ptr) == 0) 
-    {
-      glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+  blossom::system::transform::update(registry);
+  blossom::system::camera::update(registry);
 
-      blossom::system::render::update(registry);
-      glfwSwapBuffers(window.window_ptr); 
-      glfwPollEvents();
-    }
-    window.destroy();
+  while (glfwWindowShouldClose(window.window_ptr) == 0) 
+  {
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    blossom::system::render::update(registry);
+    glfwSwapBuffers(window.window_ptr); 
+    glfwPollEvents();
+  }
+  window.destroy();
 }

--- a/examples/waves.cpp
+++ b/examples/waves.cpp
@@ -26,7 +26,7 @@ auto main() -> int
   constexpr float CAMERA_FOV_Y = 90.0F;
 
   blossom::factory::camera{registry}
-    .with_width (WINDOW_WIDTH)
+  .with_width (WINDOW_WIDTH)
     .with_height(WINDOW_HEIGHT)
     .with_fov_y (CAMERA_FOV_Y)
     .with_position(CAMERA_POSITION)
@@ -34,8 +34,14 @@ auto main() -> int
     .with_type(blossom::component::camera::camera_type::PERSPECTIVE)
     .make_active();
 
-  blossom::shader waves_shader("shaders/waves.frag", "shaders/waves.vert");
-  GLint time_uniform_location = glGetUniformLocation(waves_shader.program_id, "time");
+  const blossom::shader_info SHADER_INFO
+  {
+    .vertex_shader_path   = "shaders/waves.vert",
+    .fragment_shader_path = "shaders/waves.frag"
+  };
+
+  const GLuint SHADER_PROGRAM_ID = blossom::shader::compile(SHADER_INFO);
+  GLint time_uniform_location = glGetUniformLocation(SHADER_PROGRAM_ID, "time");
 
   constexpr uint32_t TOTAL_GRID_TILES = 500;
   constexpr glm::vec2 GRID_TILE_WIDTH = {0.25F, 0.25F};
@@ -44,7 +50,7 @@ auto main() -> int
       registry,
       TOTAL_GRID_TILES,
       GRID_TILE_WIDTH,
-      waves_shader.program_id);
+      SHADER_PROGRAM_ID);
 
   blossom::system::transform::update(registry);
   blossom::system::camera::update(registry);

--- a/headers/shader.h
+++ b/headers/shader.h
@@ -10,36 +10,20 @@ namespace blossom
   class shader 
   {
     private:
-      /// @brief The path to the fragment shader's source. Specified relative to the project root.
       const char* frag_path_;
-      /// @brief The path to the vertex shader's source. Specified relative to the project root.
       const char* vert_path_;
 
-      /// @brief Compiles and links the vertex and fragment shader sources into an OpenGL program object. The OpenGL handle (ID) of this program object is stored in `shader::program_id`.
       void init_();
 
     public:
-      /// @brief Reads the source located at `path` into the output.
-      /// @return a `std::string` containing the source.
-      /// @throws std::runtime_error if the source located at `path` cannot be found.
       static auto read_source(const char* path) -> std::string;
-      /// @brief Retrieves and prints the info log for the shader object `shader`.
-      /// Used primarily for debugging shader compilation errors and warnings.
-      /// @param shader A shader object returned from [`glCreateShader()`](https://docs.gl/gl4/glCreateShader) or otherwise.
 
-      /// @brief Prints the shader log of the shader object with name `shader`.
-      /// @throws std::runtime_error if there is no current OpenGL context.
-      /// @throws std::runtime_error if `shader` is not the name of a valid shader object.
       static void print_log(GLuint shader);
-      /// @brief The OpenGL handle (ID) of the program object created in `shader::init_()`.
+
       GLuint program_id;
 
-      /// @brief Constructs a program object to which the fragment shader at `frag_path` and vertex shader at `vert_path` are linked.
-      /// The program object's OpenGL handle (ID) is stored in `shader::program_id`.
-      /// @param frag_path is the path, relative to the project root, of the fragment shader's source.
-      /// @param vert_path is the path, relative to the project root, of the vertex shader's source.
       shader(const char* frag_path, const char* vert_path);
-      /// @brief Defaulted constructor.
+
       shader() = default;
   };
 }

--- a/headers/shader.h
+++ b/headers/shader.h
@@ -15,10 +15,10 @@ namespace blossom
 
       static void print_log_(GLuint shader);
 
-      void init_();
 
     public:
       static auto read_source(const char* path) -> std::string;
+      static auto compile(const std::string& frag_path, const std::string& vert_path) -> GLuint;
 
       GLuint program_id;
 

--- a/headers/shader.h
+++ b/headers/shader.h
@@ -19,7 +19,7 @@ namespace blossom
       static void print_log_(GLuint shader);
 
     public:
-      static auto read_source(const char* path) -> std::string;
+      static auto read_source(const std::string& path) -> std::string;
       static auto compile(const shader_info& info) -> GLuint;
   };
 }

--- a/headers/shader.h
+++ b/headers/shader.h
@@ -13,12 +13,12 @@ namespace blossom
       const char* frag_path_;
       const char* vert_path_;
 
+      static void print_log_(GLuint shader);
+
       void init_();
 
     public:
       static auto read_source(const char* path) -> std::string;
-
-      static void print_log(GLuint shader);
 
       GLuint program_id;
 

--- a/headers/shader.h
+++ b/headers/shader.h
@@ -7,6 +7,12 @@
 
 namespace blossom 
 {
+  struct shader_info
+  {
+    std::string vertex_shader_path;
+    std::string fragment_shader_path;
+  };
+
   class shader 
   {
     private:
@@ -14,7 +20,7 @@ namespace blossom
 
     public:
       static auto read_source(const char* path) -> std::string;
-      static auto compile(const std::string& frag_path, const std::string& vert_path) -> GLuint;
+      static auto compile(const shader_info& info) -> GLuint;
   };
 }
 

--- a/headers/shader.h
+++ b/headers/shader.h
@@ -10,21 +10,11 @@ namespace blossom
   class shader 
   {
     private:
-      const char* frag_path_;
-      const char* vert_path_;
-
       static void print_log_(GLuint shader);
-
 
     public:
       static auto read_source(const char* path) -> std::string;
       static auto compile(const std::string& frag_path, const std::string& vert_path) -> GLuint;
-
-      GLuint program_id;
-
-      shader(const char* frag_path, const char* vert_path);
-
-      shader() = default;
   };
 }
 

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -12,7 +12,6 @@ shader::shader(const char* frag_path, const char* vert_path) :
   frag_path_(frag_path), 
   vert_path_(vert_path) 
 {
-  init_();
 }
 
 auto shader::read_source(const char* path) -> std::string
@@ -62,15 +61,15 @@ void shader::print_log_(GLuint shader)
   }
 }
 
-void shader::init_() 
+auto shader::compile(const std::string& frag_path, const std::string& vertex_path) -> GLuint
 {
   if ( glfwGetCurrentContext() == nullptr )
   {
     throw std::runtime_error("ERROR: Cannot initialise shader (there is no current OpenGL context.) Ensure that a GL context is active before shader initialisation.");
   }
 
-  std::string vertex_shader_source_string = read_source(vert_path_);
-  std::string fragment_shader_source_string = read_source(frag_path_);
+  std::string vertex_shader_source_string = read_source(vertex_path.c_str());
+  std::string fragment_shader_source_string = read_source(frag_path.c_str());
 
   const char* vertex_shader_source = vertex_shader_source_string.c_str();
   const char* fragment_shader_source = fragment_shader_source_string.c_str();
@@ -111,5 +110,6 @@ void shader::init_()
   glDeleteShader(VERTEX_SHADER);
   glDeleteShader(FRAGMENT_SHADER);
 
-  program_id = shader_program;
+  return shader_program;
+
 }

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -8,12 +8,6 @@
 
 using blossom::shader;
 
-shader::shader(const char* frag_path, const char* vert_path) : 
-  frag_path_(frag_path), 
-  vert_path_(vert_path) 
-{
-}
-
 auto shader::read_source(const char* path) -> std::string
 {
   std::string file_content;
@@ -111,5 +105,4 @@ auto shader::compile(const std::string& frag_path, const std::string& vertex_pat
   glDeleteShader(FRAGMENT_SHADER);
 
   return shader_program;
-
 }

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -36,7 +36,7 @@ void shader::print_log_(GLuint shader)
 
   if ( glIsShader(shader) == GL_FALSE )
   {
-    throw std::runtime_error("ERROR: Unable to print the shader log of an invalid shader object.");
+    throw std::invalid_argument("ERROR: Unable to print the shader log of an invalid shader object.");
   }
 
   GLsizei max_length = 0;

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -8,7 +8,7 @@
 
 using blossom::shader;
 
-auto shader::read_source(const char* path) -> std::string
+auto shader::read_source(const std::string& path) -> std::string
 {
   std::string file_content;
   std::ifstream file(path, std::ios::in);
@@ -21,7 +21,7 @@ auto shader::read_source(const char* path) -> std::string
 
   if ( !file.is_open() ) 
   {
-    throw std::runtime_error("The file" + std::string(path) + "doesn't exist.");
+    throw std::runtime_error("ERROR: The file " + path + " doesn't exist.");
   }
   file.close();
   return file_content;
@@ -62,14 +62,16 @@ auto shader::compile(const shader_info& info) -> GLuint
     throw std::runtime_error("ERROR: Cannot initialise shader (there is no current OpenGL context.) Ensure that a GL context is active before shader initialisation.");
   }
 
-  // TODO: simplify
-  const char* vertex_shader_source_code   = read_source(info.vertex_shader_path.c_str()).c_str();
-  const char* fragment_shader_source_code = read_source(info.fragment_shader_path.c_str()).c_str();
+  std::string vertex_shader_source_code   = read_source(info.vertex_shader_path);
+  std::string fragment_shader_source_code = read_source(info.fragment_shader_path);
 
-  const GLuint VERTEX_SHADER = glCreateShader(GL_VERTEX_SHADER);
+  const char* vssc_ptr =   vertex_shader_source_code.c_str();
+  const char* fssc_ptr = fragment_shader_source_code.c_str();
+
+  const GLuint VERTEX_SHADER   = glCreateShader(GL_VERTEX_SHADER);
   const GLuint FRAGMENT_SHADER = glCreateShader(GL_FRAGMENT_SHADER);
 
-  glShaderSource(VERTEX_SHADER, 1, &vertex_shader_source_code, nullptr);
+  glShaderSource(VERTEX_SHADER, 1, &vssc_ptr, nullptr);
   glCompileShader(VERTEX_SHADER);
   
   GLint vertex_shader_compilation_status;
@@ -81,7 +83,7 @@ auto shader::compile(const shader_info& info) -> GLuint
     print_log_(VERTEX_SHADER);
   }
 
-  glShaderSource(FRAGMENT_SHADER, 1, &fragment_shader_source_code, nullptr);
+  glShaderSource(FRAGMENT_SHADER, 1, &fssc_ptr, nullptr);
   glCompileShader(FRAGMENT_SHADER);
 
   GLint fragment_shader_compilation_status;

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -79,7 +79,7 @@ auto shader::compile(const std::string& frag_path, const std::string& vertex_pat
 
   if ( vertex_shader_compilation_status == GL_FALSE ) 
   {
-    std::cout << "ERROR: Vertex shader compilation failed." << "\n";
+    std::cout << "WARNING: Vertex shader compilation failed." << "\n";
     print_log_(VERTEX_SHADER);
   }
 
@@ -91,7 +91,7 @@ auto shader::compile(const std::string& frag_path, const std::string& vertex_pat
 
   if ( fragment_shader_compilation_status == GL_FALSE ) 
   {
-    std::cout << "ERROR: Fragment shader compilation failed." << "\n";
+    std::cout << "WARNING: Fragment shader compilation failed." << "\n";
     print_log_(FRAGMENT_SHADER);
   }
 

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -30,12 +30,11 @@ auto shader::read_source(const char* path) -> std::string
   {
     throw std::runtime_error("The file" + std::string(path) + "doesn't exist.");
   }
-
   file.close();
   return file_content;
 }
 
-void shader::print_log(GLuint shader)
+void shader::print_log_(GLuint shader)
 {
   if ( glfwGetCurrentContext() == nullptr )
   {
@@ -88,7 +87,7 @@ void shader::init_()
   if ( vertex_shader_compilation_status == GL_FALSE ) 
   {
     std::cout << "ERROR: Vertex shader compilation failed." << "\n";
-    print_log(VERTEX_SHADER);
+    print_log_(VERTEX_SHADER);
   }
 
   glShaderSource(FRAGMENT_SHADER, 1, &fragment_shader_source, nullptr);
@@ -100,7 +99,7 @@ void shader::init_()
   if ( fragment_shader_compilation_status == GL_FALSE ) 
   {
     std::cout << "ERROR: Fragment shader compilation failed." << "\n";
-    print_log(FRAGMENT_SHADER);
+    print_log_(FRAGMENT_SHADER);
   }
 
   GLuint shader_program = glCreateProgram();

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -57,11 +57,6 @@ void shader::print_log_(GLuint shader)
 
 auto shader::compile(const shader_info& info) -> GLuint
 {
-  if ( glfwGetCurrentContext() == nullptr )
-  {
-    throw std::runtime_error("ERROR: Cannot initialise shader (there is no current OpenGL context.) Ensure that a GL context is active before shader initialisation.");
-  }
-
   std::string vertex_shader_source_code   = read_source(info.vertex_shader_path);
   std::string fragment_shader_source_code = read_source(info.fragment_shader_path);
 

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -34,11 +34,6 @@ void shader::print_log_(GLuint shader)
     throw std::runtime_error("ERROR: Cannot print shader log. There is no current OpenGL context.");
   }
 
-  if ( glIsShader(shader) == GL_FALSE )
-  {
-    throw std::invalid_argument("ERROR: Unable to print the shader log of an invalid shader object.");
-  }
-
   GLsizei max_length = 0;
 
   glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &max_length);
@@ -74,8 +69,8 @@ auto shader::compile(const shader_info& info) -> GLuint
 
   if ( vertex_shader_compilation_status == GL_FALSE ) 
   {
-    std::cout << "WARNING: Vertex shader compilation failed." << "\n";
     print_log_(VERTEX_SHADER);
+    throw std::runtime_error("ERROR: Vertex shader compilation failed!");
   }
 
   glShaderSource(FRAGMENT_SHADER, 1, &fssc_ptr, nullptr);
@@ -86,8 +81,8 @@ auto shader::compile(const shader_info& info) -> GLuint
 
   if ( fragment_shader_compilation_status == GL_FALSE ) 
   {
-    std::cout << "WARNING: Fragment shader compilation failed." << "\n";
     print_log_(FRAGMENT_SHADER);
+    throw std::runtime_error("ERROR: Fragment shader compilation failed!");
   }
 
   GLuint shader_program = glCreateProgram();

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -55,23 +55,21 @@ void shader::print_log_(GLuint shader)
   }
 }
 
-auto shader::compile(const std::string& frag_path, const std::string& vertex_path) -> GLuint
+auto shader::compile(const shader_info& info) -> GLuint
 {
   if ( glfwGetCurrentContext() == nullptr )
   {
     throw std::runtime_error("ERROR: Cannot initialise shader (there is no current OpenGL context.) Ensure that a GL context is active before shader initialisation.");
   }
 
-  std::string vertex_shader_source_string = read_source(vertex_path.c_str());
-  std::string fragment_shader_source_string = read_source(frag_path.c_str());
-
-  const char* vertex_shader_source = vertex_shader_source_string.c_str();
-  const char* fragment_shader_source = fragment_shader_source_string.c_str();
+  // TODO: simplify
+  const char* vertex_shader_source_code   = read_source(info.vertex_shader_path.c_str()).c_str();
+  const char* fragment_shader_source_code = read_source(info.fragment_shader_path.c_str()).c_str();
 
   const GLuint VERTEX_SHADER = glCreateShader(GL_VERTEX_SHADER);
   const GLuint FRAGMENT_SHADER = glCreateShader(GL_FRAGMENT_SHADER);
 
-  glShaderSource(VERTEX_SHADER, 1, &vertex_shader_source, nullptr);
+  glShaderSource(VERTEX_SHADER, 1, &vertex_shader_source_code, nullptr);
   glCompileShader(VERTEX_SHADER);
   
   GLint vertex_shader_compilation_status;
@@ -83,7 +81,7 @@ auto shader::compile(const std::string& frag_path, const std::string& vertex_pat
     print_log_(VERTEX_SHADER);
   }
 
-  glShaderSource(FRAGMENT_SHADER, 1, &fragment_shader_source, nullptr);
+  glShaderSource(FRAGMENT_SHADER, 1, &fragment_shader_source_code, nullptr);
   glCompileShader(FRAGMENT_SHADER);
 
   GLint fragment_shader_compilation_status;

--- a/tests/shader_test.cpp
+++ b/tests/shader_test.cpp
@@ -17,28 +17,30 @@ class shader_test : public ::testing::Test
     }
 };
 
-// test that the constructor throws a std::runtime_error when there is no valid OpenGL context
-TEST_F(shader_test, constructor_with_no_gl_context_throws)
+TEST_F(shader_test, compile_with_no_gl_context_throws_runtime_error)
 {
-  EXPECT_THROW(blossom::shader("", ""), std::runtime_error);
+  const blossom::shader_info INFO = {.vertex_shader_path="shaders/default.vert", .fragment_shader_path="shaders/default.frag"};
+  EXPECT_THROW(blossom::shader::compile(INFO), std::runtime_error);
 }
 
-// test that print_log() throws a std::runtime_error when there is no valid OpenGL context
-TEST_F(shader_test, print_log_with_no_gl_context_throws)
-{
-  EXPECT_THROW(blossom::shader::print_log(INVALID_SHADER_PROGRAM), std::runtime_error);
-}
-
-// test that print_log() throws a std::runtime_error when the passed shader is valid
-TEST_F(shader_test, print_log_with_invalid_shader_throws)
+TEST_F(shader_test, compile_with_invalid_vertex_shader_throws_runtime_error)
 {
   create_dummy_window_();
-  EXPECT_THROW(blossom::shader::print_log(INVALID_SHADER_PROGRAM), std::runtime_error);
+  const blossom::shader_info INFO
+  {
+    .vertex_shader_path = "shaders/default.frag",
+    .fragment_shader_path = "shaders/default.frag"
+  };
+  EXPECT_THROW(blossom::shader::compile(INFO), std::runtime_error);
 }
 
-// test that read_source() throws a std::runtime_error when the passed path is invalid
-TEST_F(shader_test, read_source_invalid_file_path_throws)
+TEST_F(shader_test, compile_with_invalid_fragment_shader_throws_runtime_error)
 {
-  const char* invalid_path = "abcdefghijklmnopqrstuvwxyz";
-  EXPECT_THROW(blossom::shader::read_source(invalid_path), std::runtime_error);
+  create_dummy_window_();
+  const blossom::shader_info INFO
+  {
+    .vertex_shader_path = "shaders/default.vert",
+    .fragment_shader_path = "shaders/default.vert"
+  };
+  EXPECT_THROW(blossom::shader::compile(INFO), std::runtime_error);
 }


### PR DESCRIPTION
## Summary

Refactored the shader class as described in #90.

## Changelog

- `shader::print_log()` has been renamed to `shader::print_log_()` and made private.
- doxygen comments have been removed
- `init_()` has been renamed to `compile()`, reworked, and made public.
- constructors and class attributes have been removed
- added `shader_info` struct
- reworked some thrown exceptions
- updated examples
- modified shader tests

## Notes

Closes #90.